### PR TITLE
Add support for vim > 7.0 by making timeout optional

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -66,7 +66,7 @@ fu! s:SearchForMatchingTag(tagname, forwards)
     let timeout = 300
 
     " The searchpairpos() timeout parameter was added in 7.2
-    if v:version == 702
+    if v:version >= 702
       return searchpairpos(starttag, midtag, endtag, flags, skip, stopline, timeout)
     else
       return searchpairpos(starttag, midtag, endtag, flags, skip, stopline)


### PR DESCRIPTION
The `timeout` parameter for `searchpairpos()` was introduced in Vim 7.1.211, this commit will prevent Vim from throwing bunches  of errors from loading MatchTag in versions 7.0 and 7.1 
