### PR TITLE
Fix regexp error and make it more robust.

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -56,9 +56,9 @@ endfu
 fu! s:SearchForMatchingTag(tagname, forwards)
     "returns the position of a matching tag or [0 0]
 
-    let starttag = '<'.a:tagname.'.\{-}/\@<!>'
+    let starttag = '\V<'.escape(a:tagname, '\').'\.\{-}/\@<!>'
     let midtag = ''
-    let endtag = '</'.a:tagname.'.\{-}'.(a:forwards?'':'\zs').'>'
+    let endtag = '\V</'.escape(a:tagname, '\').'\.\{-}'.(a:forwards?'':'\zs').'>'
     let flags = 'nW'.(a:forwards?'':'b')
 
     " When not in a string or comment ignore matches inside them.


### PR DESCRIPTION
I've encountered nasty script errors on every cursor move when over invalid HTML. This can be avoided by limiting the tag name matching (mostly) to valid names and to include it in a _very nomagic_ search regexp for literal matching.
