### PR TITLE
FIX: Also skip tags inside XML comments.

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -63,7 +63,7 @@ fu! s:SearchForMatchingTag(tagname, forwards)
 
     " When not in a string or comment ignore matches inside them.
     let skip ='synIDattr(synID(line("."), col("."), 0), "name") ' .
-                \ '=~?  "htmlString\\|htmlCommentPart"'
+                \ '=~?  "\\%(html\\|xml\\)String\\|\\%(html\\|xml\\)CommentPart"'
     execute 'if' skip '| let skip = 0 | endif'
 
     " Limit the search to lines visible in the window.


### PR DESCRIPTION
The check only contained the syntax group names of HTML comments; there are similar syntax groups for XML. As it's hard to derive the names from the actually used filetype (it could be a custom one derived from either HTML or XML), always match both.
