### PR TITLE
FIX: Avoid matching tag names that contain the current tag name.

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -56,9 +56,9 @@ endfu
 fu! s:SearchForMatchingTag(tagname, forwards)
     "returns the position of a matching tag or [0 0]
 
-    let starttag = '\V<'.escape(a:tagname, '\').'\.\{-}/\@<!>'
+    let starttag = '\V<'.escape(a:tagname, '\').'\%(\s\.\{-}/\@<!\)\?>'
     let midtag = ''
-    let endtag = '\V</'.escape(a:tagname, '\').'\.\{-}'.(a:forwards?'':'\zs').'>'
+    let endtag = '\V</'.escape(a:tagname, '\').'\s\*'.(a:forwards?'':'\zs').'>'
     let flags = 'nW'.(a:forwards?'':'b')
 
     " When not in a string or comment ignore matches inside them.

--- a/test.html
+++ b/test.html
@@ -24,6 +24,10 @@
     </div>
 </div>
 
+<div>
+    <division>
+</div>
+
 <property>
     <property name="&lt;Super&gt;p" type="empty"/>
     <property name="&lt;Control&gt;Escape" type="empty"/>


### PR DESCRIPTION
The `.\{-}` match for the remainder is too lax; it can pick up intermediate tags where the current tag name is a subset of, e.g. the GSP `<g:else>` and `<g:elseif>` tags.
If there's content after the tag name, it must be separated by whitespace.
Also, as no attributes are allowed on the end tag, the pattern can be restricted to only optional whitespace.
