### PR TITLE
ENH: Support tags that span multiple lines.

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -40,8 +40,14 @@ fu! s:GetCurrentCursorTag()
 
     let c_col  = col('.')
     let matched = matchstr(getline('.'), '\(<[^<>]*\%'.c_col.'c.\{-}>\)\|\(\%'.c_col.'c<.\{-}>\)')
-    if matched == "" || matched =~ '/>$'
+    if matched =~ '/>$'
         return ""
+    elseif matched == ""
+        " The tag itself may be spread over multiple lines.
+        let matched = matchstr(getline('.'), '\(<[^<>]*\%'.c_col.'c.\{-}$\)\|\(\%'.c_col.'c<.\{-}$\)')
+        if matched == ""
+            return ""
+        endif
     endif
 
     " XML Tag definition is
@@ -56,9 +62,9 @@ endfu
 fu! s:SearchForMatchingTag(tagname, forwards)
     "returns the position of a matching tag or [0 0]
 
-    let starttag = '\V<'.escape(a:tagname, '\').'\.\{-}/\@<!>'
+    let starttag = '\V<'.escape(a:tagname, '\').'\%(\_s\%(\.\{-}\|\_.\{-}\%<'.line('.').'l\)/\@<!\)\?>'
     let midtag = ''
-    let endtag = '\V</'.escape(a:tagname, '\').'\.\{-}'.(a:forwards?'':'\zs').'>'
+    let endtag = '\V</'.escape(a:tagname, '\').'\_s\*'.(a:forwards?'':'\zs').'>'
     let flags = 'nW'.(a:forwards?'':'b')
 
     " When not in a string or comment ignore matches inside them.
@@ -84,9 +90,9 @@ fu! s:HighlightTagAtPosition(position)
     endif
 
     let [m_lnum, m_col] = a:position
-    exe '2match MatchParen /\(\%' . m_lnum . 'l\%' . m_col .  'c<\zs.\{-}\ze[ >]\)\|'
-                \ .'\(\%' . line('.') . 'l\%' . col('.') .  'c<\zs.\{-}\ze[ >]\)\|'
-                \ .'\(\%' . line('.') . 'l<\zs[^<> ]*\%' . col('.') . 'c.\{-}\ze[ >]\)\|'
-                \ .'\(\%' . line('.') . 'l<\zs[^<>]\{-}\ze\s[^<>]*\%' . col('.') . 'c.\{-}>\)/'
+    exe '2match MatchParen /\(\%' . m_lnum . 'l\%' . m_col .  'c<\zs.\{-}\ze[\n >]\)\|'
+                \ .'\(\%' . line('.') . 'l\%' . col('.') .  'c<\zs.\{-}\ze[\n >]\)\|'
+                \ .'\(\%' . line('.') . 'l<\zs[^<> ]*\%' . col('.') . 'c.\{-}\ze[\n >]\)\|'
+                \ .'\(\%' . line('.') . 'l<\zs[^<>]\{-}\ze\s[^<>]*\%' . col('.') . 'c.\{-}[\n>]\)/'
     let w:tag_hl_on = 1
 endfu

--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -7,7 +7,7 @@ if exists("b:did_ftplugin")
 endif
 
 augroup matchhtmlparen
-  autocmd! CursorMoved,CursorMovedI,WinEnter <buffer> call s:Highlight_Matching_Pair()
+    autocmd! CursorMoved,CursorMovedI,WinEnter <buffer> call s:Highlight_Matching_Pair()
 augroup END
 
 fu! s:Highlight_Matching_Pair()
@@ -78,9 +78,9 @@ fu! s:SearchForMatchingTag(tagname, forwards)
 
     " The searchpairpos() timeout parameter was added in 7.2
     if v:version >= 702
-      return searchpairpos(starttag, midtag, endtag, flags, skip, stopline, timeout)
+        return searchpairpos(starttag, midtag, endtag, flags, skip, stopline, timeout)
     else
-      return searchpairpos(starttag, midtag, endtag, flags, skip, stopline)
+        return searchpairpos(starttag, midtag, endtag, flags, skip, stopline)
     endif
 endfu
 
@@ -96,3 +96,5 @@ fu! s:HighlightTagAtPosition(position)
                 \ .'\(\%' . line('.') . 'l<\zs[^<>]\{-}\ze\s[^<>]*\%' . col('.') . 'c.\{-}[\n>]\)/'
     let w:tag_hl_on = 1
 endfu
+
+" vim: set ts=8 sts=4 sw=4 expandtab :

--- a/test.html
+++ b/test.html
@@ -32,6 +32,15 @@
 <img width="50" height="10"/>
 <img width="50" height="10" />
 
+<ul
+    class="foo">
+    contents
+</ul>
+<ol style="lala"
+    class="foo">
+    contents
+</ol>
+
 <div><div></div><div></div></div>
 
 <div>


### PR DESCRIPTION
Some code styles spread tags that have many attributes over multiple lines, e.g.

```
<foo bar="1"
     baz="2">
```

This patch extends the highlighting to those tags. In s:GetCurrentCursorTag(), when the current line does not contain a full tag, as a fallback the start of a tag is accepted. (It does not verify that the tag is actually properly closed in following lines.)
In s:SearchForMatchingTag(), the patterns are modified to also match newlines (while ensuring that when searching for the start tag, the current end tag is not accidentally matched). (The patterns already include the fix for subset tag names from bc576b5ead1f183f72884108bbb3d2c8763e7993.)
