### PR TITLE
FIX: Need to pass String-type skip argument to searchpairpos() now

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -70,7 +70,7 @@ fu! s:SearchForMatchingTag(tagname, forwards)
     " When not in a string or comment ignore matches inside them.
     let skip ='synIDattr(synID(line("."), col("."), 0), "name") ' .
                 \ '=~?  "\\%(html\\|xml\\)String\\|\\%(html\\|xml\\)CommentPart"'
-    execute 'if' skip '| let skip = 0 | endif'
+    execute 'if' skip '| let skip = "0" | endif'
 
     " Limit the search to lines visible in the window.
     let stopline = a:forwards ? line('w$') : line('w0')


### PR DESCRIPTION
Recent Vim versions have tightened the accepted arguments for `searchpair[pos]()`:

> 8.1.0112  no error when using bad arguments with searchpair()

The default matchparen.vim has been affected by this, and you apparently took over that code for your plugin. The fix (also taken from the latest matchparen.vim) is easy: Pass a String-type "0" instead of the number 0 in skip.